### PR TITLE
fix: starting grabbing schedule too late of one day

### DIFF
--- a/srcs/notification_producer.py
+++ b/srcs/notification_producer.py
@@ -34,8 +34,8 @@ class NotificationProducer:
     def send_weekly_schedule(self):
         """ Sends a message to the telegram chat with the weekly trash schedule. """
         schedule = self.trash_schedule_grabber.get_schedule(
-            datetime.datetime.today() + datetime.timedelta(days=1),
-            datetime.datetime.today() + datetime.timedelta(days=8)
+            datetime.datetime.today(),
+            datetime.datetime.today() + datetime.timedelta(days=7)
             )
         weekly_schedule_text = self.message_formater.get_weekly_schedule_text(schedule)
 

--- a/srcs/trash_schedule_grabbers/trash_schedule_grabber.py
+++ b/srcs/trash_schedule_grabbers/trash_schedule_grabber.py
@@ -23,9 +23,9 @@ class TrashScheduleGrabber:
 
         # making sure the dates are set and using tomorrow if not
         if from_date is None:
-            from_date = datetime.datetime.today() + datetime.timedelta(days=1)
+            from_date = datetime.datetime.today()
         if until_date is None:
-            until_date = from_date
+            until_date = from_date + datetime.timedelta(days=1)
 
         # grab events for all the event grabbers
         for grabber in self.raw_grabbers:


### PR DESCRIPTION
problem: The trashes schedule grabber was always grabbing the schedule with one day too late as per tuesday instead of monday
solution: defining the starting date as sunday evening instead of sunday evening + one day